### PR TITLE
Ensure application names with spaces in are quoted

### DIFF
--- a/fod-export/action.yml
+++ b/fod-export/action.yml
@@ -11,7 +11,7 @@ runs:
         vuln-exporter: action-default
     - run: |
         case ${FOD_RELEASE} in
-          ''|*[!0-9]*) echo '_RELEASE_OPT="--fod.release.name=${FOD_RELEASE}"' >> $GITHUB_ENV ;;
+          ''|*[!0-9]*) echo '_RELEASE_OPT=--fod.release.name="'${FOD_RELEASE}'"' >> $GITHUB_ENV ;;
           *) echo '_RELEASE_OPT="--fod.release.id=${FOD_RELEASE}"' >> $GITHUB_ENV ;;
         esac
       shell: bash
@@ -21,18 +21,18 @@ runs:
     # Uploaded the generated file containing Fortify vulnerabilities to GitHub.
     - run: |
         echo '_RELEASE_OPT=""' >> $GITHUB_ENV
-      shell: bash 
+      shell: bash
     - uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: ./gh-fortify-sast.sarif
-          
+
     # Optionally store the generated file for troubleshooting purposes.
     - uses: actions/upload-artifact@v3
       if: always()
       with:
         name: sarif-files
-        path: ./gh-fortify-sast.sarif  
-        
+        path: ./gh-fortify-sast.sarif
+
 branding:
   icon: 'shield'
   color: 'blue'

--- a/fod-export/action.yml
+++ b/fod-export/action.yml
@@ -11,7 +11,7 @@ runs:
         vuln-exporter: action-default
     - run: |
         case ${FOD_RELEASE} in
-          ''|*[!0-9]*) echo '_RELEASE_OPT=--fod.release.name="'${FOD_RELEASE}'"' >> $GITHUB_ENV ;;
+          ''|*[!0-9]*) echo '_RELEASE_OPT=--fod.release.name='''${FOD_RELEASE}'''' >> $GITHUB_ENV ;;
           *) echo '_RELEASE_OPT="--fod.release.id=${FOD_RELEASE}"' >> $GITHUB_ENV ;;
         esac
       shell: bash

--- a/ssc-export/action.yml
+++ b/ssc-export/action.yml
@@ -10,7 +10,7 @@ runs:
         vuln-exporter: action-default
     - run: |
         case ${SSC_APPVERSION} in
-          ''|*[!0-9]*) echo '_APPVERSION_OPT="--ssc.version.name=${SSC_APPVERSION}"' >> $GITHUB_ENV ;;
+          ''|*[!0-9]*) echo '_APPVERSION_OPT="--ssc.version.name="'${SSC_APPVERSION}'"' >> $GITHUB_ENV ;;
           *) echo '_APPVERSION_OPT="--ssc.version.id=${SSC_APPVERSION}"' >> $GITHUB_ENV ;;
         esac
       shell: bash
@@ -19,19 +19,19 @@ runs:
         cmd: '"${VULN_EXPORTER_CMD}" SSCToGitHub "--ssc.baseUrl=${SSC_URL}" "--ssc.user=${SSC_USER}" "--ssc.password=${SSC_PASSWORD}" "--ssc.authToken=${SSC_TOKEN}" "${_APPVERSION_OPT}"'
     - run: |
         echo '_APPVERSION_OPT=""' >> $GITHUB_ENV
-      shell: bash 
+      shell: bash
     # Uploaded the generated file containing Fortify vulnerabilities to GitHub.
     - uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: ./gh-fortify-sast.sarif
-          
+
     # Optionally store the generated file for troubleshooting purposes.
     - uses: actions/upload-artifact@v3
       if: always()
       with:
         name: sarif-files
-        path: ./gh-fortify-sast.sarif  
-        
+        path: ./gh-fortify-sast.sarif
+
 branding:
   icon: 'shield'
   color: 'blue'

--- a/ssc-export/action.yml
+++ b/ssc-export/action.yml
@@ -10,7 +10,7 @@ runs:
         vuln-exporter: action-default
     - run: |
         case ${SSC_APPVERSION} in
-          ''|*[!0-9]*) echo '_APPVERSION_OPT="--ssc.version.name="'${SSC_APPVERSION}'"' >> $GITHUB_ENV ;;
+          ''|*[!0-9]*) echo '_APPVERSION_OPT="--ssc.version.name='''${SSC_APPVERSION}'''' >> $GITHUB_ENV ;;
           *) echo '_APPVERSION_OPT="--ssc.version.id=${SSC_APPVERSION}"' >> $GITHUB_ENV ;;
         esac
       shell: bash

--- a/ssc-export/action.yml
+++ b/ssc-export/action.yml
@@ -10,7 +10,7 @@ runs:
         vuln-exporter: action-default
     - run: |
         case ${SSC_APPVERSION} in
-          ''|*[!0-9]*) echo '_APPVERSION_OPT="--ssc.version.name='''${SSC_APPVERSION}'''' >> $GITHUB_ENV ;;
+          ''|*[!0-9]*) echo '_APPVERSION_OPT=--ssc.version.name='''${SSC_APPVERSION}'''' >> $GITHUB_ENV ;;
           *) echo '_APPVERSION_OPT="--ssc.version.id=${SSC_APPVERSION}"' >> $GITHUB_ENV ;;
         esac
       shell: bash


### PR DESCRIPTION
Minor change to ensure any FoD or SSC application version names are quoted so that `FortifyVulnerabilityExporter` works correctly.